### PR TITLE
LCDを日本語で表示するモジュールを追加しました

### DIFF
--- a/device/LCD/JLCD.py
+++ b/device/LCD/JLCD.py
@@ -1,0 +1,49 @@
+import mojimoji
+from LCD import LCD
+
+class JLCD(LCD):
+    
+    # message method override
+    def message(self, string, line = 1):
+        
+        #文字コードnの文字 ＝ n番目の文字
+        codes = u'線線線線線線線線線線線線線線線線　　　　　　　　　　　　　　　　!"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}→←　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　　。「」、・ヲァィゥェォャュョッーアイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワン゛゜αäβεμσρq√陰ι×￠￡nöpqθ∞ΩüΣπxν千万円÷　塗'
+        #変換する文字の辞書(ex.「バ」＝「ハ」「゛」)
+        dic ={u'ガ':u'カ゛',u'ギ':u'キ゛',u'グ':u'ク゛',u'ゲ':u'ケ゛',u'ゴ':u'コ゛',u'ザ':u'サ゛',u'ジ':u'シ゛',u'ズ':u'ス゛',u'ゼ':u'セ゛',u'ゾ':u'ソ゛',u'ダ':u'タ゛',u'ヂ':u'チ゛',u'ヅ':u'ツ゛',u'デ':u'テ゛',u'ド':u'ト゛',u'バ':u'ハ゛',u'ビ':u'ヒ゛',u'ブ':u'フ゛',u'ベ':u'ヘ゛',u'ボ':u'ホ゛',u'パ':u'ハ゜',u'ピ':u'ヒ゜',u'プ':u'フ゜',u'ペ':u'ヘ゜',u'ポ':u'ホ゜',u'℃':u'゜C'}
+        
+        # display message string on LCD line 1 or 2
+        if line == 1:
+            lcd_line = self.LCD_LINE_1
+        elif line == 2:
+            lcd_line = self.LCD_LINE_2
+        else:
+            raise ValueError('line number must be 1 or 2')
+
+        string = string.ljust(self.LCD_WIDTH," ")
+
+        self.lcd_byte(lcd_line, self.LCD_CMD)
+
+                
+        # 半角カナのみ全角へ
+        string = mojimoji.han_to_zen(string, ascii=False, digit=False)
+        # 全角数字のみ半角へ
+        string = mojimoji.zen_to_han(string, ascii=False, kana=False)
+
+        # for i in range(self.LCD_WIDTH):
+        #     self.lcd_byte(ord(string[i]), self.LCD_CHR)
+        #濁音など、文字の変換        
+        string2 = ""
+        for i in range(self.LCD_WIDTH):
+            if ( string[i] in dic.keys() ):
+                string2 += dic[string[i]]
+            else:
+                string2 += string[i]
+        
+        #文字コードのリストにある文字なら表示、それ以外は表示しない
+        for i in range(self.LCD_WIDTH):
+            if (codes.find(string2[i]) >= 0):
+                self.lcd_byte(codes.find(string2[i])+1,self.LCD_CHR)
+            elif (string2[i] == u' '):
+                self.lcd_byte(0x10,self.LCD_CHR)
+            else:
+                self.lcd_byte(0xFF,self.LCD_CHR)

--- a/device/LCD/LCD.py
+++ b/device/LCD/LCD.py
@@ -1,0 +1,89 @@
+import smbus
+import time
+
+class LCD:
+    def __init__(self, pi_rev = 2, i2c_addr = 0x3F, backlight = True):
+
+        # device constants
+        self.I2C_ADDR  = i2c_addr
+        self.LCD_WIDTH = 16   # Max. characters per line
+
+        self.LCD_CHR = 1 # Mode - Sending data
+        self.LCD_CMD = 0 # Mode - Sending command
+
+        self.LCD_LINE_1 = 0x80 # LCD RAM addr for line one
+        self.LCD_LINE_2 = 0xC0 # LCD RAM addr for line two
+
+        if backlight:
+            # on
+            self.LCD_BACKLIGHT  = 0x08
+        else:
+            # off
+            self.LCD_BACKLIGHT = 0x00
+
+        self.ENABLE = 0b00000100 # Enable bit
+
+        # Timing constants
+        self.E_PULSE = 0.0005
+        self.E_DELAY = 0.0005
+
+        # Open I2C interface
+        if pi_rev == 2:
+            # Rev 2 Pi uses 1
+            self.bus = smbus.SMBus(1)
+        elif pi_rev == 1:
+            # Rev 1 Pi uses 0
+            self.bus = smbus.SMBus(0)
+        else:
+            raise ValueError('pi_rev param must be 1 or 2')
+
+        # Initialise display
+        self.lcd_byte(0x33, self.LCD_CMD) # 110011 Initialise
+        self.lcd_byte(0x32, self.LCD_CMD) # 110010 Initialise
+        self.lcd_byte(0x06, self.LCD_CMD) # 000110 Cursor move direction
+        self.lcd_byte(0x0C, self.LCD_CMD) # 001100 Display On,Cursor Off, Blink Off
+        self.lcd_byte(0x28, self.LCD_CMD) # 101000 Data length, number of lines, font size
+        self.lcd_byte(0x01, self.LCD_CMD) # 000001 Clear display
+
+    def lcd_byte(self, bits, mode):
+        # Send byte to data pins
+        # bits = data
+        # mode = 1 for data, 0 for command
+
+        bits_high = mode | (bits & 0xF0) | self.LCD_BACKLIGHT
+        bits_low = mode | ((bits<<4) & 0xF0) | self.LCD_BACKLIGHT
+
+        # High bits
+        self.bus.write_byte(self.I2C_ADDR, bits_high)
+        self.toggle_enable(bits_high)
+
+        # Low bits
+        self.bus.write_byte(self.I2C_ADDR, bits_low)
+        self.toggle_enable(bits_low)
+
+    def toggle_enable(self, bits):
+        time.sleep(self.E_DELAY)
+        self.bus.write_byte(self.I2C_ADDR, (bits | self.ENABLE))
+        time.sleep(self.E_PULSE)
+        self.bus.write_byte(self.I2C_ADDR,(bits & ~self.ENABLE))
+        time.sleep(self.E_DELAY)
+
+    def message(self, string, line = 1):
+        # display message string on LCD line 1 or 2
+        if line == 1:
+            lcd_line = self.LCD_LINE_1
+        elif line == 2:
+            lcd_line = self.LCD_LINE_2
+        else:
+            raise ValueError('line number must be 1 or 2')
+
+        string = string.ljust(self.LCD_WIDTH," ")
+
+        self.lcd_byte(lcd_line, self.LCD_CMD)
+
+        for i in range(self.LCD_WIDTH):
+            self.lcd_byte(ord(string[i]), self.LCD_CHR)
+
+    def clear(self):
+        # clear LCD display
+        self.lcd_byte(0x01, self.LCD_CMD)


### PR DESCRIPTION
## 概要
LCDに文字を表示させるプログラムです。
JLCD.pyで日本語対応しているので、JLCDのmessage関数を使うとカタカナで表示できます

例
from import JLCD as LCD

lcd = LCD(2, 0x27, True)
lcd.message('ホゲホゲフガフガ')

## 補足
もし動かなかったimportのpathが間違えてる可能性があるので修正してもらって構いません