### PR TITLE
データベース接続情報を外部に隔離。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# データベース接続情報を保存しているファイルです。
+device/connect_database.py

--- a/device/Adafruit_DHT/dht22.py
+++ b/device/Adafruit_DHT/dht22.py
@@ -1,13 +1,9 @@
 from uuid import getnode as get_mac
 import Adafruit_DHT as DHT
-import smbus
-import time
-import datetime
-import MySQLdb
-import random
-import math
-
-connection = MySQLdb.connect(host='air-data.cheanwi3tf0d.ap-northeast-1.rds.amazonaws.com',user='root',passwd='Ar4dBV8J',db='air_data',charset='utf8')
+import smbus,time,datetime,pymysql,random,math
+from device import connect_database as db
+pymysql.install_as_MySQLdb()
+connection = db.connect_air_database()
 cursor = connection.cursor()
 
 SENSOR_TYPE = DHT.DHT22
@@ -106,7 +102,7 @@ def main():
             cursor.execute("INSERT INTO device_data VALUES('" + str(mac) + "','" + "Temp" + "','" + str(t1) + "','" + str(time) + "')")
             cursor.execute("INSERT INTO device_data VALUES('" + str(mac) + "','" + "Humid" + "','" + str(h1) + "','" + str(time) + "')")
                 
-        except MySQLdb.Error as e:
+        except pymysql.Error as e:
             print(e)
             
         break

--- a/device/requirements.txt
+++ b/device/requirements.txt
@@ -1,4 +1,5 @@
 DateTime==4.3
-mysqlclient==2.0.1
+PyMySQL==0.10.1
 pytz==2020.4
+PyYAML==5.3.1
 zope.interface==5.2.0


### PR DESCRIPTION
## 概要

データベース接続情報が漏洩していたので外部ファイルに隔離した。
パスワードはすでに変更済み。（新パスワードはTrelloをご確認ください。）

データベース接続のための外部ファイルをdevice/connect_database.pyとして設置してください。
Trelloのカード https://trello.com/c/7dwMEC3n の添付ファイルからDLしてください。
